### PR TITLE
BugFix: integer round turned off

### DIFF
--- a/R/module_feature_general.R
+++ b/R/module_feature_general.R
@@ -239,7 +239,7 @@ feature_general_module <- function(input, output, session,
     tab <- tab[, grep("^General\\|", colnames(tab)), drop = FALSE]
     tab <- tab[reactive_i(), , drop = FALSE]
     ic <- vapply(tab, is.numeric, logical(1)) & vapply(tab, is.integer, logical(1))
-    tab[ic] <- lapply(tab[ic], signif, digits = 2)
+    #tab[ic] <- lapply(tab[ic], signif, digits = 2)
     colnames(tab) <- sub('General\\|All\\|', "", colnames(tab))
     tab
   })

--- a/R/module_sample_general.R
+++ b/R/module_sample_general.R
@@ -167,7 +167,7 @@ sample_general_module <- function(input, output, session, reactive_phenoData, re
     tab <- tab[, grep("^General\\|", colnames(tab)), drop = FALSE]
     tab <- tab[reactive_j(), , drop = FALSE]
     ic <- vapply(tab, is.numeric, logical(1)) & vapply(tab, is.integer, logical(1))
-    tab[ic] <- lapply(tab[ic], signif, digits = 2)
+    #tab[ic] <- lapply(tab[ic], signif, digits = 2)
     colnames(tab) <- sub('General\\|All\\|', "", colnames(tab))
     tab
   })


### PR DESCRIPTION
For some columns like peptides start point wrong annotation will be obtained if we round those fields